### PR TITLE
Added support for detecting cancelled payments properly

### DIFF
--- a/src/Message/CompletePurchaseResponse.php
+++ b/src/Message/CompletePurchaseResponse.php
@@ -14,6 +14,11 @@ class CompletePurchaseResponse extends AbstractResponse
         return isset($this->data['transStatus']) && 'Y' === $this->data['transStatus'];
     }
 
+    public function isCancelled()
+    {
+        return isset($this->data['transStatus']) && 'C' === $this->data['transStatus'];
+    }
+
     public function getTransactionReference()
     {
         return isset($this->data['transId']) ? $this->data['transId'] : null;

--- a/tests/Message/CompletePurchaseResponseTest.php
+++ b/tests/Message/CompletePurchaseResponseTest.php
@@ -18,9 +18,28 @@ class CompletePurchaseResponseTest extends TestCase
         );
 
         $this->assertTrue($response->isSuccessful());
+        $this->assertFalse($response->isCancelled());
         $this->assertFalse($response->isRedirect());
         $this->assertSame('abc123', $response->getTransactionReference());
         $this->assertSame('Success Message', $response->getMessage());
+    }
+
+    public function testCompletePurchaseCancel()
+    {
+        $response = new CompletePurchaseresponse(
+            $this->getMockRequest(),
+            array(
+                'transStatus' => 'C',
+                'transId' => null,
+                'rawAuthMessage' => 'Declined'
+            )
+        );
+
+        $this->assertFalse($response->isSuccessful());
+        $this->assertTrue($response->isCancelled());
+        $this->assertFalse($response->isRedirect());
+        $this->assertNull($response->getTransactionReference());
+        $this->assertSame('Declined', $response->getMessage());
     }
 
     public function testCompletePurchaseFailure()
@@ -35,6 +54,7 @@ class CompletePurchaseResponseTest extends TestCase
         );
 
         $this->assertFalse($response->isSuccessful());
+        $this->assertFalse($response->isCancelled());
         $this->assertFalse($response->isRedirect());
         $this->assertNull($response->getTransactionReference());
         $this->assertSame('Declined', $response->getMessage());


### PR DESCRIPTION
Just a tiny patch to detect cancelled payments.

The transStatus field can actually also have a status 'N', which is used in callbacks for recurring payments, but that's not relevant here.