### PR TITLE
Add additional options

### DIFF
--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -72,6 +72,11 @@ class Gateway extends AbstractGateway
         return $this->setParameter('callbackPassword', $value);
     }
 
+    /**
+     * If true, hides WorldPay's language selection menu.
+     *
+     * @param boolean
+     */
     public function getNoLanguageMenu()
     {
         return $this->getParameter('noLanguageMenu');
@@ -82,6 +87,11 @@ class Gateway extends AbstractGateway
         return $this->setParameter('noLanguageMenu', $value);
     }
 
+    /**
+     * If true, prevents editing of address details by user.
+     *
+     * @param boolean
+     */
     public function getFixContact()
     {
         return $this->getParameter('fixContact');
@@ -92,6 +102,11 @@ class Gateway extends AbstractGateway
         return $this->setParameter('fixContact', $value);
     }
 
+    /**
+     * If true, hides address details from user.
+     *
+     * @param boolean
+     */
     public function getHideContact()
     {
         return $this->getParameter('hideContact');

--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -26,6 +26,9 @@ class Gateway extends AbstractGateway
             'secretWord' => '',
             'callbackPassword' => '',
             'testMode' => false,
+            'noLanguageMenu' => false,
+            'fixContact' => false,
+            'hideContact' => false,
         );
     }
 
@@ -67,6 +70,36 @@ class Gateway extends AbstractGateway
     public function setCallbackPassword($value)
     {
         return $this->setParameter('callbackPassword', $value);
+    }
+
+    public function getNoLanguageMenu()
+    {
+        return $this->getParameter('noLanguageMenu');
+    }
+
+    public function setNoLanguageMenu($value)
+    {
+        return $this->setParameter('noLanguageMenu', $value);
+    }
+
+    public function getFixContact()
+    {
+        return $this->getParameter('fixContact');
+    }
+
+    public function setFixContact($value)
+    {
+        return $this->setParameter('fixContact', $value);
+    }
+
+    public function getHideContact()
+    {
+        return $this->getParameter('hideContact');
+    }
+
+    public function setHideContact($value)
+    {
+        return $this->setParameter('hideContact', $value);
     }
 
     public function purchase(array $parameters = array())

--- a/src/Message/PurchaseRequest.php
+++ b/src/Message/PurchaseRequest.php
@@ -52,6 +52,12 @@ class PurchaseRequest extends AbstractRequest
         return $this->setParameter('callbackPassword', $value);
     }
 
+    /**
+     * Pre-selects the card type being used and bypasses the card type selection screen.
+     * Must match one of: https://support.worldpay.com/support/kb/bg/customisingadvanced/custa9102.html
+     *
+     * @param string
+     */
     public function getPaymentType()
     {
         return $this->getParameter('paymentType');
@@ -62,6 +68,11 @@ class PurchaseRequest extends AbstractRequest
         return $this->setParameter('paymentType', $value);
     }
 
+    /**
+     * If true, hides WorldPay's language selection menu.
+     *
+     * @param boolean
+     */
     public function getNoLanguageMenu()
     {
         return $this->getParameter('noLanguageMenu');
@@ -72,6 +83,11 @@ class PurchaseRequest extends AbstractRequest
         return $this->setParameter('noLanguageMenu', $value);
     }
 
+    /**
+     * If true, prevents editing of address details by user.
+     *
+     * @param boolean
+     */
     public function getFixContact()
     {
         return $this->getParameter('fixContact');
@@ -82,6 +98,11 @@ class PurchaseRequest extends AbstractRequest
         return $this->setParameter('fixContact', $value);
     }
 
+    /**
+     * If true, hides address details from user.
+     *
+     * @param boolean
+     */
     public function getHideContact()
     {
         return $this->getParameter('hideContact');

--- a/src/Message/PurchaseRequest.php
+++ b/src/Message/PurchaseRequest.php
@@ -52,6 +52,46 @@ class PurchaseRequest extends AbstractRequest
         return $this->setParameter('callbackPassword', $value);
     }
 
+    public function getPaymentType()
+    {
+        return $this->getParameter('paymentType');
+    }
+
+    public function setPaymentType($value)
+    {
+        return $this->setParameter('paymentType', $value);
+    }
+
+    public function getNoLanguageMenu()
+    {
+        return $this->getParameter('noLanguageMenu');
+    }
+
+    public function setNoLanguageMenu($value)
+    {
+        return $this->setParameter('noLanguageMenu', $value);
+    }
+
+    public function getFixContact()
+    {
+        return $this->getParameter('fixContact');
+    }
+
+    public function setFixContact($value)
+    {
+        return $this->setParameter('fixContact', $value);
+    }
+
+    public function getHideContact()
+    {
+        return $this->getParameter('hideContact');
+    }
+
+    public function setHideContact($value)
+    {
+        return $this->setParameter('hideContact', $value);
+    }
+
     public function getData()
     {
         $this->validate('amount', 'returnUrl');
@@ -65,6 +105,10 @@ class PurchaseRequest extends AbstractRequest
         $data['currency'] = $this->getCurrency();
         $data['testMode'] = $this->getTestMode() ? 100 : 0;
         $data['MC_callback'] = $this->getReturnUrl();
+        $data['paymentType'] = $this -> getPaymentType();
+        $data['noLanguageMenu'] = $this -> getNoLanguageMenu();
+        $data['fixContact'] = $this -> getFixContact();
+        $data['hideContact'] = $this -> getHideContact();
 
         if ($this->getCard()) {
             $data['name'] = $this->getCard()->getName();


### PR DESCRIPTION
paymentType to bypass card selection screen (must match one of:
https://support.worldpay.com/support/kb/bg/customisingadvanced/custa9102.html)
noLanguageMenu to hide language menu
fixContact to lock address details on payment screen
hideContact to hide address details on payment screen

Fixes #5 