### PR TITLE
Enable use of notifyUrl

### DIFF
--- a/src/Message/PurchaseRequest.php
+++ b/src/Message/PurchaseRequest.php
@@ -54,7 +54,13 @@ class PurchaseRequest extends AbstractRequest
 
     public function getData()
     {
-        $this->validate('amount', 'returnUrl');
+        $this->validate('amount');
+
+        // Either the nodifyUrl or the returnUrl can be provided.
+        // The returnUrl is deprecated, as strictly this is a notifyUrl.
+        if (!$this->getNotifyUrl()) {
+            $this->validate('returnUrl');
+        }
 
         $data = array();
         $data['instId'] = $this->getInstallationId();
@@ -64,7 +70,7 @@ class PurchaseRequest extends AbstractRequest
         $data['amount'] = $this->getAmount();
         $data['currency'] = $this->getCurrency();
         $data['testMode'] = $this->getTestMode() ? 100 : 0;
-        $data['MC_callback'] = $this->getReturnUrl();
+        $data['MC_callback'] = $this->getNotifyUrl() ?: $this->getReturnUrl();
 
         if ($this->getCard()) {
             $data['name'] = $this->getCard()->getName();


### PR DESCRIPTION
This change reflects the fact that the server-to-server callback for WorldPay really should be set using `notifyUrl`, whilst maintaining backwards compatibility with users using `returnUrl`.