### PR TITLE
signatureFields as configurable parameter

### DIFF
--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -27,8 +27,19 @@ class Gateway extends AbstractGateway
             'noLanguageMenu' => false,
             'fixContact' => false,
             'hideContact' => false,
-            'hideCurrency' => false
+            'hideCurrency' => false,
+            'signatureFields' => 'instId:amount:currency:cartId',
         );
+    }
+
+    public function getSignatureFields()
+    {
+        return $this->getParameter('signatureFields');
+    }
+
+    public function setSignatureFields($value)
+    {
+        return $this->setParameter('signatureFields', $value);
     }
 
     public function getInstallationId()

--- a/src/Message/PurchaseRequest.php
+++ b/src/Message/PurchaseRequest.php
@@ -11,6 +11,12 @@ class PurchaseRequest extends AbstractRequest
 {
     protected $liveEndpoint = 'https://secure.worldpay.com/wcc/purchase';
     protected $testEndpoint = 'https://secure-test.worldpay.com/wcc/purchase';
+    protected $signatureFields = 'instId:amount:currency:cartId';
+
+    public function getSignatureFields()
+    {
+        return $this->getParameter('signatureFields') ?: $this->signatureFields;
+    }
 
     public function getInstallationId()
     {
@@ -166,7 +172,7 @@ class PurchaseRequest extends AbstractRequest
         }
 
         if ($this->getSecretWord()) {
-            $data['signatureFields'] = 'instId:amount:currency:cartId';
+            $data['signatureFields'] = $this->getSignatureFields();
             $signature_data = array($this->getSecretWord(),
                 $data['instId'], $data['amount'], $data['currency'], $data['cartId']);
             $data['signature'] = md5(implode(':', $signature_data));

--- a/src/Message/PurchaseRequest.php
+++ b/src/Message/PurchaseRequest.php
@@ -11,11 +11,15 @@ class PurchaseRequest extends AbstractRequest
 {
     protected $liveEndpoint = 'https://secure.worldpay.com/wcc/purchase';
     protected $testEndpoint = 'https://secure-test.worldpay.com/wcc/purchase';
-    protected $signatureFields = 'instId:amount:currency:cartId';
+
+    public function setSignatureFields($value)
+    {
+        return $this->setParameter('signatureFields', $value);
+    }
 
     public function getSignatureFields()
     {
-        return $this->getParameter('signatureFields') ?: $this->signatureFields;
+        return $this->getParameter('signatureFields');
     }
 
     public function getInstallationId()

--- a/tests/Message/PurchaseRequestTest.php
+++ b/tests/Message/PurchaseRequestTest.php
@@ -28,6 +28,8 @@ class PurchaseRequestTest extends TestCase
                 'amount' => '12.00',
                 'currency' => 'GBP',
                 'returnUrl' => 'https://example.com/return',
+                'signatureFields' => 'instId:amount:currency',
+                'secretWord' => 'such-secret-wow'
             )
         );
 
@@ -41,6 +43,9 @@ class PurchaseRequestTest extends TestCase
         $this->assertSame('GBP', $data['currency']);
         $this->assertSame(0, $data['testMode']);
         $this->assertSame('https://example.com/return', $data['MC_callback']);
+        $this->assertSame('instId:amount:currency', $data['signatureFields']);
+        $this->assertInternalType('string', $data['signature']);
+        $this->assertEquals(32, strlen($data['signature']));
     }
 
     public function testGetDataTestMode()


### PR DESCRIPTION
added changes to make signatureFields a configurable parameter. WorldPay allows this field to be customised in their admin panel and it can be different for each payment account installation. In our current use case we have signatureKey configured in different order and with additional fields.