### PR TITLE
Using signatureParams and authMode

### DIFF
--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -29,7 +29,18 @@ class Gateway extends AbstractGateway
             'hideContact' => false,
             'hideCurrency' => false,
             'signatureFields' => 'instId:amount:currency:cartId',
+            'authMode' => ''
         );
+    }
+
+    public function setAuthMode($value)
+    {
+        return $this->setParameter('authMode', $value);
+    }
+
+    public function getAuthMode()
+    {
+        return $this->getParameter('authMode');
     }
 
     public function getSignatureFields()

--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -29,7 +29,7 @@ class Gateway extends AbstractGateway
             'hideContact' => false,
             'hideCurrency' => false,
             'signatureFields' => 'instId:amount:currency:cartId',
-            'authMode' => ''
+            'authMode' => 'A'
         );
     }
 

--- a/src/Message/PurchaseRequest.php
+++ b/src/Message/PurchaseRequest.php
@@ -12,6 +12,16 @@ class PurchaseRequest extends AbstractRequest
     protected $liveEndpoint = 'https://secure.worldpay.com/wcc/purchase';
     protected $testEndpoint = 'https://secure-test.worldpay.com/wcc/purchase';
 
+    public function setAuthMode($value)
+    {
+        return $this->setParameter('authMode', $value);
+    }
+
+    public function getAuthMode()
+    {
+        return $this->getParameter('authMode');
+    }
+
     public function setSignatureFields($value)
     {
         return $this->setParameter('signatureFields', $value);
@@ -162,6 +172,7 @@ class PurchaseRequest extends AbstractRequest
         $data['fixContact'] = $this -> getFixContact();
         $data['hideContact'] = $this -> getHideContact();
         $data['hideCurrency'] = $this -> getHideCurrency();
+        $data['authMode'] = $this->getAuthMode();
 
         if ($this->getCard()) {
             $data['name'] = $this->getCard()->getName();
@@ -177,8 +188,11 @@ class PurchaseRequest extends AbstractRequest
 
         if ($this->getSecretWord()) {
             $data['signatureFields'] = $this->getSignatureFields();
-            $signature_data = array($this->getSecretWord(),
-                $data['instId'], $data['amount'], $data['currency'], $data['cartId']);
+            $signature_data = array($this->getSecretWord());
+            foreach (explode(':', $data['signatureFields']) as $parameterName) {
+                $signature_data[] = $data[$parameterName];
+            }
+
             $data['signature'] = md5(implode(':', $signature_data));
         }
 

--- a/tests/Message/PurchaseRequestTest.php
+++ b/tests/Message/PurchaseRequestTest.php
@@ -29,7 +29,8 @@ class PurchaseRequestTest extends TestCase
                 'currency' => 'GBP',
                 'returnUrl' => 'https://example.com/return',
                 'signatureFields' => 'instId:amount:currency',
-                'secretWord' => 'such-secret-wow'
+                'secretWord' => 'such-secret-wow',
+                'authMode' => 'A'
             )
         );
 
@@ -41,6 +42,7 @@ class PurchaseRequestTest extends TestCase
         $this->assertSame('food', $data['desc']);
         $this->assertSame('12.00', $data['amount']);
         $this->assertSame('GBP', $data['currency']);
+        $this->assertSame('A', $data['authMode']);
         $this->assertSame(0, $data['testMode']);
         $this->assertSame('https://example.com/return', $data['MC_callback']);
         $this->assertSame('instId:amount:currency', $data['signatureFields']);


### PR DESCRIPTION
Added authMode as a parameter. This option specifies the authorisation mode used. The values are "A" for a full auth, or "E" for a pre-auth, as documented here: http://support.worldpay.com/support/kb/bg/paymentresponse/pr5201.html

Also added building signature based on configured signature params

I tested this on our sandbox and confirmed that authentication and process works.