### PR TITLE
apply signatureFields config in when building signature data

### DIFF
--- a/src/Message/PurchaseRequest.php
+++ b/src/Message/PurchaseRequest.php
@@ -177,8 +177,11 @@ class PurchaseRequest extends AbstractRequest
 
         if ($this->getSecretWord()) {
             $data['signatureFields'] = $this->getSignatureFields();
-            $signature_data = array($this->getSecretWord(),
-                $data['instId'], $data['amount'], $data['currency'], $data['cartId']);
+            $signature_data = array($this->getSecretWord());
+            foreach (explode(':', $data['signatureFields']) as $parameterName) {
+                $signature_data[] = $data[$parameterName];
+            }
+
             $data['signature'] = md5(implode(':', $signature_data));
         }
 


### PR DESCRIPTION
Hi,

This pull request is to actually apply signatureFields configuration if it is different than default setting. Currently PurchaseRequest is building signature_data using fixed order of parameters and ignoring the custom parameter.

Thanks,
