### PR TITLE
json purchase request results in malformed json

### DIFF
--- a/src/Message/JsonPurchaseRequest.php
+++ b/src/Message/JsonPurchaseRequest.php
@@ -26,9 +26,8 @@ class JsonPurchaseRequest extends JsonAbstractRequest
 
         $card = $this->getCard();
 
-        $data['billingAddress'] = array();
-
         if ($card) {
+            $data['billingAddress'] = array();
             $data['billingAddress']['address1'] = $card->getBillingAddress1();
             $data['billingAddress']['address2'] = $card->getBillingAddress2();
             $data['billingAddress']['city'] = $card->getBillingCity();


### PR DESCRIPTION
when not passing in billing address details. if card is not passed in, billingAddress ends up as an empty object which throws and error in WorldPay