### PR TITLE
Remove unspecified requirement of php-http/guzzle6-adapter

### DIFF
--- a/src/JsonGateway.php
+++ b/src/JsonGateway.php
@@ -2,7 +2,6 @@
 
 namespace Omnipay\WorldPay;
 
-use Http\Adapter\Guzzle6\Client;
 use Omnipay\Common\AbstractGateway;
 
 /**
@@ -142,17 +141,5 @@ class JsonGateway extends AbstractGateway
     public function capture(array $parameters = array())
     {
         return $this->createRequest('\Omnipay\WorldPay\Message\JsonCaptureRequest', $parameters);
-    }
-
-    protected function getDefaultHttpClient()
-    {
-        $guzzleClient = Client::createWithConfig([
-            'curl.options' => [
-                CURLOPT_SSLVERSION => 6
-            ]
-        ]);
-
-
-        return new \Omnipay\Common\Http\Client($guzzleClient);
     }
 }


### PR DESCRIPTION
The removed code force the `php-http/client-implementation` to be `php-http/guzzle6-adapter` and this is very limiting. The only reason for this that I can see is to set the SSL encryption that should be used but the client should be able to negotiate the best SSL encryption without it being specified.